### PR TITLE
Add Lean compatible conjectures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 # macOS Desktop Services
 .DS_Store
+mathlib4/

--- a/classes/conjecture.py
+++ b/classes/conjecture.py
@@ -268,4 +268,36 @@ class MultiLinearConjecture(Conjecture):
             print("Cannot plot multi-linear conjectures")
             return None
 
+    def to_lean(self):
+        """Return a Lean statement encoding the conjecture."""
+        ineq_map = {"<=": "≤", ">=": "≥", "=": "="}
+        lean_var = {
+            "order": "Fintype.card V",
+            "size": "Finset.card G.edgeFinset",
+            "chromatic_number": "G.chromaticNumber",
+        }
+
+        lhs = lean_var.get(self.conclusion.lhs, f"{self.conclusion.lhs} G")
+
+        rhs_terms = []
+        for m, var in zip(self.conclusion.slopes, self.conclusion.rhs):
+            term = lean_var.get(var, f"{var} G")
+            if m == 1:
+                rhs_terms.append(term)
+            else:
+                rhs_terms.append(f"({m}) * {term}")
+
+        rhs = " + ".join(rhs_terms)
+        if self.conclusion.intercept != 0:
+            rhs += f" + {self.conclusion.intercept}"
+
+        inequality = ineq_map.get(self.conclusion.inequality, self.conclusion.inequality)
+
+        hypothesis = "(hG : G.Connected)" if self.hypothesis.statement == "a connected graph" else ""
+
+        return (
+            "theorem generated {V} [Fintype V] (G : SimpleGraph V) "
+            f"{hypothesis} : {lhs} {inequality} {rhs} := by\n  sorry"
+        )
+
 

--- a/functions/formating.py
+++ b/functions/formating.py
@@ -8,6 +8,7 @@ __all__ =[
     'str_to_fraction',
     'conjecture_to_dict',
     'conjecture_to_latex',
+    'conjecture_to_lean',
     'multi_radio',
     'rows_multi_radio',
     'def_map',
@@ -743,6 +744,36 @@ def conjecture_to_latex(conjecture):
     )
 
     return tex_string
+
+
+def conjecture_to_lean(conjecture):
+    ineq_map = {"<=": "≤", ">=": "≥", "=": "="}
+    lean_var = {
+        "order": "Fintype.card V",
+        "size": "Finset.card G.edgeFinset",
+        "chromatic_number": "G.chromaticNumber",
+    }
+
+    lhs = lean_var.get(conjecture.conclusion.lhs, f"{conjecture.conclusion.lhs} G")
+
+    rhs_terms = []
+    for slope, var in zip(conjecture.conclusion.slopes, conjecture.conclusion.rhs):
+        term = lean_var.get(var, f"{var} G")
+        if slope == 1:
+            rhs_terms.append(term)
+        else:
+            rhs_terms.append(f"({slope}) * {term}")
+    rhs = " + ".join(rhs_terms)
+    if conjecture.conclusion.intercept != 0:
+        rhs += f" + {conjecture.conclusion.intercept}"
+
+    inequality = ineq_map.get(conjecture.conclusion.inequality, conjecture.conclusion.inequality)
+    hypothesis = "(hG : G.Connected)" if conjecture.hypothesis.statement == "a connected graph" else ""
+
+    return (
+        "theorem generated {V} [Fintype V] (G : SimpleGraph V) "
+        f"{hypothesis} : {lhs} {inequality} {rhs} := by\n  sorry"
+    )
 
 
 def multi_radio(label, options):

--- a/pages/2_Generate_Conjectures.py
+++ b/pages/2_Generate_Conjectures.py
@@ -6,6 +6,7 @@ from functions import (
     rows_multi_radio,
     multi_radio,
     conjecture_to_latex,
+    conjecture_to_lean,
     conjecture_to_dict,
     def_map,
     tex_map,
@@ -154,6 +155,7 @@ def generate_conjectures():
                 hypothesis = tex_map(conjecture.hypothesis.statement)
                 st.write(f"{hypothesis}")
                 st.latex(conjecture_to_latex(conjecture))
+                st.code(conjecture_to_lean(conjecture), language="lean")
                 st.write(r" $\text{with equality on }$" +  f"{conjecture.touch}" +  r"$\text{ graphs in the known collection of graphs.}$")
 
                 lhs = conjecture.conclusion.lhs

--- a/pages/3_Generate_MIP_Conjectures.py
+++ b/pages/3_Generate_MIP_Conjectures.py
@@ -6,6 +6,7 @@ from functions import (
     invariants,
     booleans,
     conjecture_to_latex,
+    conjecture_to_lean,
     conjecture_to_dict,
     def_map,
     tex_map,
@@ -155,6 +156,7 @@ def generate_conjectures():
                 hypothesis = tex_map(conjecture.hypothesis.statement)
                 st.write(f"{hypothesis}")
                 st.latex(conjecture_to_latex(conjecture))
+                st.code(conjecture_to_lean(conjecture), language="lean")
                 st.write(r" $\text{with equality on }$" +  f"{conjecture.touch}" +  r"$\text{ graphs in the known collection of graphs.}$")
 
                 lhs = conjecture.conclusion.lhs

--- a/tests/test_lean.py
+++ b/tests/test_lean.py
@@ -1,0 +1,27 @@
+import os
+import sys
+from fractions import Fraction
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from classes.conjecture import Hypothesis, MultiLinearConclusion, MultiLinearConjecture
+
+import importlib.util
+import types
+
+spec = importlib.util.spec_from_file_location(
+    'formating', os.path.join(os.path.dirname(__file__), '..', 'functions', 'formating.py')
+)
+formating = importlib.util.module_from_spec(spec)
+sys.modules['streamlit'] = types.SimpleNamespace()
+spec.loader.exec_module(formating)
+conjecture_to_lean = formating.conjecture_to_lean
+
+
+def test_conjecture_to_lean():
+    hyp = Hypothesis("a connected graph")
+    concl = MultiLinearConclusion("order", "<=", [Fraction(1)], ["order"], Fraction(0))
+    conj = MultiLinearConjecture(hyp, concl)
+    lean = conjecture_to_lean(conj)
+    assert "SimpleGraph" in lean
+    assert "≤" in lean


### PR DESCRIPTION
## Summary
- add `.gitignore` entry for mathlib4
- support Lean theorem formatting via `to_lean`
- expose `conjecture_to_lean` helper
- display Lean code on conjecture pages
- test Lean rendering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa73c6a34833390158d47f55d8be1