### PR TITLE
Add conjecture generator utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,17 @@ on the heuristic for more details.
 
 
 For a detailed mathematical description of **TxGraffiti**'s algorithms and the history of automated conjecturing in mathematics, see our preprint on arXiv: [arXiv preprint 2409.19379](https://arxiv.org/abs/2409.19379)
+## Conjecture Generator Utility
+
+A small standalone script lives in `utils/conjecture_generator.py`. It outputs a sequence
+of Lean `conjecture` statements similar to those in Graffiti Conjectures 100.
+Run it directly from the command line:
+
+```bash
+python utils/conjecture_generator.py        # prints 100 conjectures
+python utils/conjecture_generator.py 50 > demo.lean
+```
+
+The optional numeric argument controls how many conjectures are emitted. You can
+redirect the output into a `.lean` file and paste it into Lean for exploration.
+

--- a/tests/test_conjecture_generator.py
+++ b/tests/test_conjecture_generator.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_generator_emits_requested_number():
+    script = Path(__file__).resolve().parents[1] / "utils" / "conjecture_generator.py"
+    result = subprocess.run([sys.executable, str(script), "3"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert result.stdout.count("conjecture ") == 3
+    assert "namespace AutoGraffiti" in result.stdout

--- a/utils/conjecture_generator.py
+++ b/utils/conjecture_generator.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""
+conjecture_generator.py
+=======================
+
+A tiny standalone script that **from Python** emits TxGraffiti-style Lean conjectures.
+It interleaves natural-language comments with Lean `conjecture` stubs, matching the
+style of *Graffiti Conjectures 100*.
+
+Usage
+-----
+    python conjecture_generator.py                # prints 100 conjectures to stdout
+    python conjecture_generator.py 50 > foo.lean  # prints first 50 into foo.lean
+
+Customisation
+-------------
+* Edit the `INVARIANTS` list to include the graph-invariant names you care about
+  (they must already exist—or be stubbed—in your Lean environment).
+* Tweak `K_RANGE` and `C_RANGE` for the coefficient search space.
+* Adjust `BOUND_LIMIT` or pass a CLI argument to control how many conjectures are
+  emitted.
+
+The output is pure Lean source: you can pipe it into a `.lean` file or paste the
+string into the canvas.
+"""
+
+import itertools
+import sys
+import textwrap
+
+# ---- PARAMETERS ---------------------------------------------------------
+
+INVARIANTS = [
+    "independence_number",
+    "chromatic_number",
+    "matching_number",
+    "clique_number",
+    "vertex_cover_number",
+    "min_edge_cover",
+    "diameter",
+    "radius",
+    "triameter",
+    "randic_index",
+    "harmonic_index",
+    "sum_connectivity_index",
+    "residue",
+    "annihilation_number",
+    "sub_total_domination_number",
+    "slater",
+    "wiener_index",
+]
+
+K_RANGE = [1, 2, 3, 4]   # multiplicative coefficients k
+C_RANGE = [1, 2, 3, 4]   # additive shifts c
+
+BOUND_LIMIT = 100        # default number of conjectures produced
+
+# ---- HELPER -------------------------------------------------------------
+
+def pretty_comment(idx: int, lhs: str, k: int, rhs: str, c: int) -> str:
+    lhs_name = lhs.replace("_", " ")
+    rhs_name = rhs.replace("_", " ")
+    return textwrap.fill(
+        f"Conjecture {idx}: For every finite simple graph G, "
+        f"{lhs_name}(G) ≤ {k} * {rhs_name}(G) + {c}.",
+        width=78,
+    )
+
+def lean_ident(lhs: str, k: int, rhs: str, c: int) -> str:
+    return f"{lhs}_le_{k}_{rhs}{'' if c==0 else f'_plus_{c}'}"
+
+def conjecture_block(idx: int, lhs: str, k: int, rhs: str, c: int) -> str:
+    comment = pretty_comment(idx, lhs, k, rhs, c)
+    ident   = lean_ident(lhs, k, rhs, c)
+    rhs_term = f"{k} * {rhs} G + {c}" if k != 1 else f"{rhs} G + {c}"
+    return textwrap.dedent(f"""
+        /- {comment} -/
+        conjecture {ident} (G : SimpleGraph V) [Fintype V] :
+          {lhs} G ≤ {rhs_term} := by
+          sorry
+    """)
+
+# ---- MAIN ---------------------------------------------------------------
+
+def main() -> None:
+    try:
+        limit = int(sys.argv[1])
+    except (IndexError, ValueError):
+        limit = BOUND_LIMIT
+
+    header = textwrap.dedent("""
+        import Mathlib.Data.Nat.Basic
+        import Mathlib.Combinatorics.SimpleGraph.Basic
+
+        namespace AutoGraffiti
+
+        variable {V : Type*}
+    """)
+
+    conjectures = []
+    idx = 1
+    for lhs, rhs in itertools.product(INVARIANTS, repeat=2):
+        if lhs == rhs:
+            continue  # skip trivial self-bounds
+        for k, c in itertools.product(K_RANGE, C_RANGE):
+            conjectures.append(conjecture_block(idx, lhs, k, rhs, c))
+            idx += 1
+            if len(conjectures) >= limit:
+                break
+        if len(conjectures) >= limit:
+            break
+    lean_source = header + "\n".join(conjectures) + "\nend AutoGraffiti\n"
+    print(lean_source)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `conjecture_generator.py` utility to emit Lean conjecture stubs
- document how to use the generator in the README
- add regression test covering the new utility

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b788d763c833384e9a608c86a0fe6